### PR TITLE
Open Graph と Twitter Card の画像変更

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,13 +18,13 @@
   <meta property="og:description" content="{{page.description}}">
   <meta property="og:url" content="https://dojocon2018.coderdojo.jp{{ page.url }}">
   <meta property="og:site_name" content="DojoCon Japan 2018">
-  <meta property="og:image" content="https://dojocon2018.coderdojo.jp/img/mainvisual.png">
-  <meta property="og:image:secure_url" content="https://dojocon2018.coderdojo.jp/img/mainvisual.png">
+  <meta property="og:image" content="https://dojocon2018.coderdojo.jp/img/og_image_1200x630.png">
+  <meta property="og:image:secure_url" content="https://dojocon2018.coderdojo.jp/img/og_image_1200x630.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:description" content="{{page.description}}">
   <meta name="twitter:title" content="{{ page.j-title }} - {{ page.title }} | DojoCon Japan 2018">
   <meta name="twitter:site" content="@DojoConJapan">
-  <meta name="twitter:image" content="http://dojocon2018.coderdojo.jp/img/mainvisual.png">
+  <meta name="twitter:image" content="http://dojocon2018.coderdojo.jp/img/og_image_1200x630.png">
   <link rel="icon" href="/img/cropped-favicon-32x32.png" sizes="32x32">
   <link rel="icon" href="/img/cropped-favicon-192x192.png" sizes="192x192">
   <link rel="/img/cropped-favicon-180x180.png">


### PR DESCRIPTION
現在 mainvisual.png になっているところ、og_image_1200x630.png に差し替えました。