### PR TITLE
Topページ の NEWSセクションの "News一覧へ" ボタンの表記を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ layout: default
     {% endfor %}
   </div>
   <div class="text-center">
-    <a class="btn btn__white btn__xxl" href="/news/" role="button">New一覧へ</a>
+    <a class="btn btn__white btn__xxl" href="/news/" role="button">News一覧へ</a>
   </div>
 </div>
 </section>


### PR DESCRIPTION
resolved #39 

- トップページの NEWS セクションのボタンのテキストを "New一覧へ" を "News一覧へ" に変更。

気になってしまったもので...()
勝手にやったことなので容赦なく蹴ってくださって構いません 💦 