### PR TITLE
【セッション：ひばりヶ丘】文言の変更 issue #58

### DIFF
--- a/_session/1350_masao-niizuma.md
+++ b/_session/1350_masao-niizuma.md
@@ -5,7 +5,7 @@ description: "CoderDojoひばりヶ丘その記録-子供達は何を学んで�
 thumbnail: niizuma.jpg
 speaker-name : 新妻 正夫（にいづま まさお）
 time-schedule: 13:50-14:10
-position: CoderDojoひばりヶ丘 主催
+position: CoderDojoひばりヶ丘 主宰
 speaker-info: "
 サイボウズ公認kintoneエバンジェリスト、ペライチ公認埼玉県代表サポーター、コワーキング協同組合理事。<br>
 2012年よりCoderDojoひばりヶ丘を主催。56才のScratcherでもある。


### PR DESCRIPTION
CDひばりヶ丘 新妻さんの紹介文
> CoderDojo ひばりヶ丘　主催

の "主催" →  "主宰" に変更

close #58 