### PR TITLE
スポンサー部分の「スポンサー募集」リンクを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,8 +267,6 @@ layout: default
 
   </div>
 
-  <p class="text-center mb-5 mt-5">現在スポンサー企業様を募集しております<br><a href="/sponsor.html">詳しくはこちらをご覧ください。</a></p>
-
 </div>
 
 </section>


### PR DESCRIPTION
'現在スポンサー企業様を募集しております' の部分です。

<img width="393" alt="2018-08-18 9 21 25" src="https://user-images.githubusercontent.com/32048271/44293643-1e481700-a2c8-11e8-9706-d66301747af4.png">
